### PR TITLE
Add slash to links to avoid unnecessary redirects

### DIFF
--- a/Sources/Publish/API/PlotComponents.swift
+++ b/Sources/Publish/API/PlotComponents.swift
@@ -133,7 +133,7 @@ public extension Node where Context: HTMLLinkableContext {
     /// Assign a path to link the element to, using its `href` attribute.
     /// - parameter path: The absolute path to assign.
     static func href(_ path: Path) -> Node {
-        .href(path.absoluteString)
+        .href(path.absoluteString + "/")
     }
 }
 


### PR DESCRIPTION
Ref: https://github.com/JohnSundell/Publish/pull/79

Links to folder content generated by Publish don't seem to end with a trailing "/", which means there will be an additional HTTP redirect request to the resource with the path appended. You can see an example of this by going to https://swiftbysundell.com/articles/the-decade-of-swift in Safari: you will see it redirected to https://swiftbysundell.com/articles/the-decade-of-swift/, which is an unnecessary redirect.

This is more obvious when using curl:

```shell
marc@bix ~ % curl -v https://swiftbysundell.com/articles/the-decade-of-swift
  … blah blah blah …
< location: https://swiftbysundell.com/articles/the-decade-of-swift/
< 
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://swiftbysundell.com/articles/the-decade-of-swift/">here</a>.</p>
</body></html>
* Connection #0 to host swiftbysundell.com left intact
* Closing connection 0
```

TBH, I have no idea of this patch is the correct solution to this inefficiency, but in the absence of an issue tracker, there's no other forum for describing the issue.