### PR TITLE
Change convenience API to allow pre- and post-generation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Here’s how we could extend our basic `publish()` call from before to inject ou
 ```swift
 try DeliciousRecipes().publish(
     withTheme: .foundation,
-    additionalSteps: [
+    preGenerationSteps: [
         // Add an item programmatically
         .addItem(Item(
             path: "my-favorite-recipe",

--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -60,8 +60,10 @@ public extension Website {
     /// - parameter rssFeedSections: What sections to include in the site's RSS feed.
     /// - parameter rssFeedConfig: The configuration to use for the site's RSS feed.
     /// - parameter deploymentMethod: How to deploy the website.
-    /// - parameter additionalSteps: Any additional steps to add to the publishing
+    /// - parameter preGenerationSteps: Additional steps to add to the publishing
     ///   pipeline. Will be executed right before the HTML generation process begins.
+    /// - parameter postGenerationSteps: Additional steps to add to the publishing pipeline.
+    ///   Will be executed after generation steps, right before the deployment process begins.
     /// - parameter plugins: Plugins to be installed at the start of the publishing process.
     /// - parameter file: The file that this method is called from (auto-inserted).
     /// - parameter line: The line that this method is called from (auto-inserted).
@@ -72,7 +74,8 @@ public extension Website {
                  rssFeedSections: Set<SectionID> = Set(SectionID.allCases),
                  rssFeedConfig: RSSFeedConfiguration? = .default,
                  deployedUsing deploymentMethod: DeploymentMethod<Self>? = nil,
-                 additionalSteps: [PublishingStep<Self>] = [],
+                 preGenerationSteps: [PublishingStep<Self>] = [],
+                 postGenerationSteps: [PublishingStep<Self>] = [],
                  plugins: [Plugin<Self>] = [],
                  file: StaticString = #file) throws -> PublishedWebsite<Self> {
         try publish(
@@ -82,7 +85,7 @@ public extension Website {
                 .optional(.copyResources()),
                 .addMarkdownFiles(),
                 .sortItems(by: \.date, order: .descending),
-                .group(additionalSteps),
+                .group(preGenerationSteps),
                 .generateHTML(withTheme: theme, indentation: indentation),
                 .unwrap(rssFeedConfig) { config in
                     .generateRSSFeed(
@@ -91,6 +94,7 @@ public extension Website {
                     )
                 },
                 .generateSiteMap(indentedBy: indentation),
+                .group(postGenerationSteps),
                 .unwrap(deploymentMethod, PublishingStep.deploy)
             ],
             file: file

--- a/Tests/PublishTests/Infrastructure/PublishTestCase.swift
+++ b/Tests/PublishTests/Infrastructure/PublishTestCase.swift
@@ -29,7 +29,8 @@ class PublishTestCase: XCTestCase {
         in folder: Folder? = nil,
         using theme: Theme<WebsiteStub.WithoutItemMetadata>,
         content: [Path : String] = [:],
-        additionalSteps: [PublishingStep<WebsiteStub.WithoutItemMetadata>] = [],
+        preGenerationSteps: [PublishingStep<WebsiteStub.WithoutItemMetadata>] = [],
+        postGenerationSteps: [PublishingStep<WebsiteStub.WithoutItemMetadata>] = [],
         plugins: [Plugin<WebsiteStub.WithoutItemMetadata>] = [],
         expectedHTML: [Path : String],
         allowWhitelistedOutputFiles: Bool = true,
@@ -48,7 +49,8 @@ class PublishTestCase: XCTestCase {
             withTheme: theme,
             at: Path(folder.path),
             rssFeedSections: [],
-            additionalSteps: additionalSteps,
+            preGenerationSteps: preGenerationSteps,
+            postGenerationSteps: postGenerationSteps,
             plugins: plugins
         )
 


### PR DESCRIPTION
From https://github.com/JohnSundell/Publish/pull/70:

> ## Changes
> 
> The convenience API `publish(withTheme...)` has had the parameter `additionalSteps` renamed to `preGenerationSteps`, and has gained the parameter `postGenerationSteps`.
> 
> _**This is a breaking change**_ for anyone currently using the `additionalSteps` parameter, requiring them to switch to the new parameter name. It will not affect anyone using the `publish(withTheme...)` function but not calling the `additionalSteps` parameter.
> 
> ## Motivation
> 
> Although most `PublishingSteps` must be run before HTML generation, some must be run after.
> For example, the HTML produced by Ink, Plot, Publish, and various plugins may be formatted and indented inconsistently. To use any kind of HTML prettifying/validation tool, you must have access to the rendered HTML in its entirety, which is not possible until after generation.
> 
> Currently, the convenience API `publish(withTheme...)` includes a parameter called `additionalSteps`, but these are applied before HTML generation. This PR splits that into two parameters, which specify steps to be run before and after generation.
> 
> Although these post-generation steps can be added using the `publish(at:using:)` function, it requires significantly more setup, hence the change to the convenience API.
> 
> ## Alternatives Considered
> 
> 1. Use the `@deprecated` attribute to leave the existing function and add the new one. Since the function names are the same, the compiler cannot accurately predict when to use the warning, especially when neither of the extra step parameters are in use. This causes an unfixable warning if you don't use the parameter at all.
> 2. Leave `additionalSteps` as is, and add the `postGenerationSteps` parameter. This avoids the breaking change, but is more ambiguous. Steps that must be run after generation might be inadvertently added to `additionalSteps` due to its name.
> 
> ## Follow-up
> Once the status of this PR is decided, I'll add some documentation demonstrating pre- and post-generation steps. I should have my TidyHTMLPublishStep repo online by then as an example.