### PR TITLE
Make publish function async

### DIFF
--- a/Resources/FoundationTheme/styles.css
+++ b/Resources/FoundationTheme/styles.css
@@ -102,7 +102,7 @@ a {
 }
 
 .tag-list {
-    margin-bottom: 15px;
+    margin-bottom: 10px;
 }
 
 .tag-list li,
@@ -113,6 +113,7 @@ a {
     padding: 4px 6px;
     border-radius: 5px;
     margin-right: 5px;
+    margin-bottom: 5px;
 }
 
 .tag-list a,
@@ -136,6 +137,7 @@ a {
 .all-tags li {
     font-size: 1.4em;
     margin-right: 10px;
+    margin-bottom: 10px;
     padding: 6px 10px;
 }
 

--- a/Sources/Publish/API/Theme+Foundation.swift
+++ b/Sources/Publish/API/Theme+Foundation.swift
@@ -24,7 +24,7 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
             .lang(context.site.language),
             .head(for: index, on: context.site),
             .body {
-                SiteHeader(context: context, selectedSelectionID: nil)
+                SiteHeader(context: context, selectedSectionID: nil)
                 Wrapper {
                     H1(index.title)
                     Paragraph(context.site.description)
@@ -49,7 +49,7 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
             .lang(context.site.language),
             .head(for: section, on: context.site),
             .body {
-                SiteHeader(context: context, selectedSelectionID: section.id)
+                SiteHeader(context: context, selectedSectionID: section.id)
                 Wrapper {
                     H1(section.title)
                     ItemList(items: section.items, site: context.site)
@@ -67,7 +67,7 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
             .body(
                 .class("item-page"),
                 .components {
-                    SiteHeader(context: context, selectedSelectionID: item.sectionID)
+                    SiteHeader(context: context, selectedSectionID: item.sectionID)
                     Wrapper {
                         Article {
                             Div(item.content.body).class("content")
@@ -87,7 +87,7 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
             .lang(context.site.language),
             .head(for: page, on: context.site),
             .body {
-                SiteHeader(context: context, selectedSelectionID: nil)
+                SiteHeader(context: context, selectedSectionID: nil)
                 Wrapper(page.body)
                 SiteFooter()
             }
@@ -100,7 +100,7 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
             .lang(context.site.language),
             .head(for: page, on: context.site),
             .body {
-                SiteHeader(context: context, selectedSelectionID: nil)
+                SiteHeader(context: context, selectedSectionID: nil)
                 Wrapper {
                     H1("Browse all tags")
                     List(page.tags.sorted()) { tag in
@@ -124,7 +124,7 @@ private struct FoundationHTMLFactory<Site: Website>: HTMLFactory {
             .lang(context.site.language),
             .head(for: page, on: context.site),
             .body {
-                SiteHeader(context: context, selectedSelectionID: nil)
+                SiteHeader(context: context, selectedSectionID: nil)
                 Wrapper {
                     H1 {
                         Text("Tagged with ")
@@ -161,7 +161,7 @@ private struct Wrapper: ComponentContainer {
 
 private struct SiteHeader<Site: Website>: Component {
     var context: PublishingContext<Site>
-    var selectedSelectionID: Site.SectionID?
+    var selectedSectionID: Site.SectionID?
 
     var body: Component {
         Header {
@@ -184,7 +184,7 @@ private struct SiteHeader<Site: Website>: Component {
                 return Link(section.title,
                     url: section.path.absoluteString
                 )
-                .class(sectionID == selectedSelectionID ? "selected" : "")
+                .class(sectionID == selectedSectionID ? "selected" : "")
             }
         }
     }

--- a/Sources/Publish/API/Website.swift
+++ b/Sources/Publish/API/Website.swift
@@ -130,6 +130,67 @@ public extension Website {
         semaphore.wait()
         return try result!.get()
     }
+    
+    /// Publish this website using a default pipeline. To build a completely
+    /// custom pipeline, use the `publish(using:)` method.
+    /// - parameter theme: The HTML theme to generate the website using.
+    /// - parameter indentation: How to indent the generated files.
+    /// - parameter path: Any specific path to generate the website at.
+    /// - parameter rssFeedSections: What sections to include in the site's RSS feed.
+    /// - parameter rssFeedConfig: The configuration to use for the site's RSS feed.
+    /// - parameter deploymentMethod: How to deploy the website.
+    /// - parameter additionalSteps: Any additional steps to add to the publishing
+    ///   pipeline. Will be executed right before the HTML generation process begins.
+    /// - parameter plugins: Plugins to be installed at the start of the publishing process.
+    /// - parameter file: The file that this method is called from (auto-inserted).
+    /// - parameter line: The line that this method is called from (auto-inserted).
+    @discardableResult
+    func publish(withTheme theme: Theme<Self>,
+                 indentation: Indentation.Kind? = nil,
+                 at path: Path? = nil,
+                 rssFeedSections: Set<SectionID> = Set(SectionID.allCases),
+                 rssFeedConfig: RSSFeedConfiguration? = .default,
+                 deployedUsing deploymentMethod: DeploymentMethod<Self>? = nil,
+                 additionalSteps: [PublishingStep<Self>] = [],
+                 plugins: [Plugin<Self>] = [],
+                 file: StaticString = #file) async throws -> PublishedWebsite<Self> {
+        try await publish(
+            at: path,
+            using: [
+                .group(plugins.map(PublishingStep.installPlugin)),
+                .optional(.copyResources()),
+                .addMarkdownFiles(),
+                .sortItems(by: \.date, order: .descending),
+                .group(additionalSteps),
+                .generateHTML(withTheme: theme, indentation: indentation),
+                .unwrap(rssFeedConfig) { config in
+                    .generateRSSFeed(
+                        including: rssFeedSections,
+                        config: config
+                    )
+                },
+                .generateSiteMap(indentedBy: indentation),
+                .unwrap(deploymentMethod, PublishingStep.deploy)
+            ],
+            file: file
+        )
+    }
+    
+    /// Publish this website using a custom pipeline.
+    /// - parameter path: Any specific path to generate the website at.
+    /// - parameter steps: The steps to use to form the website's publishing pipeline.
+    /// - parameter file: The file that this method is called from (auto-inserted).
+    /// - parameter line: The line that this method is called from (auto-inserted).
+    @discardableResult
+    func publish(at path: Path? = nil,
+                 using steps: [PublishingStep<Self>],
+                 file: StaticString = #file) async throws -> PublishedWebsite<Self> {
+        let pipeline = PublishingPipeline(
+            steps: steps,
+            originFilePath: Path("\(file)")
+        )
+        return try await pipeline.execute(for: self, at: path)
+    }
 }
 
 // MARK: - Paths and URLs


### PR DESCRIPTION
From https://github.com/JohnSundell/Publish/pull/141:

> The internal semaphore used to make the CLI wait for publish to finish is no longer necessary and causes problems with concurrency. This PR removes it and makes the publish function async.
> 
> * Is no longer necessary because Swift already supports async main, so one can build CLIs that use async and automatically await for the work to finish.
> * It cause problems because is blocking the main thread. If any async code needs to run on the MainActor this causes a deadlock.